### PR TITLE
Working version of Julia interface to MPSolve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,12 @@ os:
     - linux
 julia:
     - nightly
-    - 0.4
-    - 0.3
+    - 1.3
 notifications:
     email: false
 before_install:
     - sudo apt-add-repository -y ppa:leo.robol/mpsolve
     - sudo apt-get update -qq
-    - sudo apt-get install -y libmps3
+    - sudo apt-get install -y libmps3-dev
 script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - if [ -f test/runtests.jl ]; then julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.test("MPSolve", coverage=false)'; fi
+ - julia --color=yes -e 'using Pkg; Pkg.test(coverage=false)'

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,10 @@
+name = "MPSolve"
+uuid = "9b0ab244-28a7-517c-931e-75c4e3199a6c"
+authors = ["Leonardo Robol <leo@robol.it>"]
+version = "0.1.0"
+
+[deps]
+Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
+
+[compat]
+julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,7 @@
 name = "MPSolve"
 uuid = "9b0ab244-28a7-517c-931e-75c4e3199a6c"
-authors = ["Leonardo Robol <leo@robol.it>"]
-version = "0.1.0"
-
-[deps]
-Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
+authors = ["Leonardo Robol <leo@robol.it>","Mikhail Kagalenko <kagalenko.m.b@rsreu.ru"]
+version = "0.9"
 
 [compat]
-julia = "1"
+julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,10 @@
 name = "MPSolve"
 uuid = "9b0ab244-28a7-517c-931e-75c4e3199a6c"
-authors = ["Leonardo Robol <leo@robol.it>","Mikhail Kagalenko <kagalenko.m.b@rsreu.ru"]
-version = "0.9"
+authors = ["Leonardo Robol <leo@robol.it>", "Mikhail Kagalenko <kagalenko.m.b@rsreu.ru"]
+version = "0.9.0"
+
+[deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1.3"

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 # MPSolve.jl
 This repository contains the Julia interface to the MPSolve
-polynomial rootfinder. You can install it in your Julia environment
-by typing 
+polynomial rootfinder. It requires Julia version no less than 1.3-RC4. You can
+install the package in your Julia environment by typing 
 ```
- julia> Pkg.clone("git://github.com/robol/MPSolve.jl.git")
+ julia> Pkg.add("https://github.com/robol/MPSolve.jl.git")
 ```
-Notice that, in order to use the package, you will need to have
+Notice that in order to use the package, you will need to have
 libmps available on the system. See the official [MPSolve website](http://numpi.dm.unipi.it/mpsolve/)
 for instructions on getting MPSolve up and running. 
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.3
-Polynomials

--- a/src/MPSolve.jl
+++ b/src/MPSolve.jl
@@ -127,10 +127,8 @@ end
 
 _gmp_clear!(c::Mpsc) = _gmp_clear!([c.r, c.i])
 
-_gmp_clear!(m::Array{T}) where T<:Union{Mpz, Mpq, Mpf, Mpsc} = begin
-    map(_gmp_clear!,m);
-    nothing
-end
+_gmp_clear!(m::Array{T}) where T<:Union{Mpz, Mpq, Mpf, Mpsc} = (_gmp_clear!.(m);
+                                                                nothing)
 
 struct Rdpe
     r::Cdouble
@@ -234,9 +232,9 @@ function get_roots(context)
               (Ref{Cvoid}, Ref{Ref{Mpsc}}, Ref{Ref{Rdpe}}),
               context, roots_p, rds_p)
     end
-    roots = map(complex, roots_m)
+    roots = complex.(roots_m)
     _gmp_clear!(roots_m)
-    radii = map(Float64, rds)
+    radii = Float64.(rds)
     (roots, radii)
 end
 
@@ -251,7 +249,7 @@ function get_roots_d(context)
               (Ref{Cvoid}, Ref{Ptr{Cplx}}, Ref{Ptr{Cdouble}}),
               context, roots_p, radii_p)
     end
-    roots = map(complex, roots_c)
+    roots = complex.(roots_c)
     (roots,radii)
 end
 

--- a/src/MPSolve.jl
+++ b/src/MPSolve.jl
@@ -32,9 +32,10 @@ struct Mpq  <: Real
     den::Mpz
 
     Mpq() = Mpq(0)
-    Mpq(i::T) where T<: Signed = Mpq(i, 1)
+    Mpq(i::T) where T<:Signed = Mpq(i, 1)
     Mpq(q::Rational{T}) where T<:Signed = Mpq(q.num, q.den)
-    function Mpq(num, den) where  T<:Signed
+    Mpq(num::T, den::S) where  {T, S<:Signed} = Mpq(BigInt(num), BigInt(den))
+    function Mpq(num::BigInt, den::BigInt)
         q = Ref{Mpq}()
         ccall((:__gmpq_init, :libgmp), Cvoid, (Ref{Mpq},), q)
         ccall((:__gmpq_set_num, :libgmp), Cvoid, (Ref{Mpq},Ref{BigInt}),
@@ -52,8 +53,7 @@ struct Mpq  <: Real
     end
 end
 
-Base.convert(::Type{Mpq}, x::T) where T<:Union{Signed,Rational} =
-    Mpq(x)
+Base.convert(::Type{Mpq}, x::T) where T<:Union{Signed,Rational} = Mpq(x)
 
 Base.Rational(q::Mpq) = Rational(BigInt(q.num), BigInt(q.den))
 

--- a/src/MPSolve.jl
+++ b/src/MPSolve.jl
@@ -2,180 +2,246 @@ module MPSolve
 
 using Polynomials
 
-export mps_roots
+import Base: convert,show
+import Base.GMP: BigInt
+using Base.GMP: Limb, MPZ, BigInt
 
-# 
-# The following is taken from the discussion that can be found
-# at https://groups.google.com/forum/#!msg/julia-dev/uqp7LziUEfY/9RkiymZY5twJ. 
-# 
-immutable mpz_struct
-   alloc::Cint
-   size::Cint
-   d::Ptr{Void}
+#export mps_roots
+export MpzStruct,MpqStruct,prnt,clear,BigInt # ,mpz_t
+
+struct MpzStruct
+    alloc::Cint
+    size::Cint
+    d::Ptr{Limb}
+
+    MpzStruct() = MpzStruct(0)
+    MpzStruct(b::T) where T<:Signed = MpzStruct(BigInt(b))
+    function MpzStruct(b::BigInt)
+        m = Ref{MpzStruct}()
+        GC.@preserve m begin
+            ccall((:__gmpz_init, :libgmp), Cvoid, (Ref{MpzStruct},), m)
+            ccall((:__gmpz_set, :libgmp), Cvoid, (Ref{MpzStruct},Ref{BigInt}),
+                  m, b)
+            return m[]
+        end
+    end
 end
 
-Base.convert(::Type{mpz_struct}, i::BigInt) = mpz_struct(i.alloc, i.size, i.d)
-
-type mpq_struct
-     num::mpz_struct
-     den::mpz_struct
-     mpq_struct(num, den) = new(num, den)
-     mpq_struct(q::Rational{BigInt}) = mpq_struct(q.num, q.den)
-     mpq_struct() = new() # uninitialized
+function BigInt(m::MpzStruct)
+    b = BigInt()
+    ccall((:__gmpz_set, :libgmp), Cvoid, (Ref{BigInt},Ref{MpzStruct}), b, m)
+    return b
 end
 
-immutable mpf_struct
+function prnt(m::MpzStruct)
+    ccall((:__gmp_printf,:libgmp), Cvoid, (Cstring,Ref{MpzStruct},), "%Zd",m)
+end
+
+function show(io::IO, m::MpzStruct)
+    b = BigInt(m)
+    print(io,"MpzStruct(", b, ")")
+end
+
+function prnt(m::MpzStruct)
+    ccall((:__gmp_printf,:libgmp), Cvoid, (Cstring,Ref{MpzStruct},), "%Zd\n",m)
+end
+
+clear(m::MpzStruct) = begin
+    ccall((:__gmpz_clear, :libgmp), Cvoid, (Ref{MpzStruct},), m)
+end
+
+# const mpz_t = Ref{MpzStruct}
+             
+mutable struct MpqStruct
+    num::MpzStruct
+    den::MpzStruct
+
+    MpqStruct() = MpqStruct(MpzStruct(), MpzStruct())
+    MpqStruct(q::Rational{T}) where T<: Signed = MpqStruct(q.num, q.den)
+    function MpqStruct(num, den)
+        q = new(MpzStruct(num), MpzStruct(den))
+        finalizer(x-> begin
+                  clear(x.num)
+                  clear(x.den)
+                  end, q)
+    end
+end
+
+show(io::IO, q::MpqStruct) = begin
+    show(io, q.num)
+    print(io, "//")
+    show(io, q.den)
+end
+
+# Arbitrary precision floating point type from gmp.h
+# is different from Julia's BigFloat
+struct MpfStruct
     mp_prec::Cint
     mp_size::Cint
-    mp_exp::Cint
-    mp_d::Ptr{Void}
+    mp_exp::Clong
+    mp_d::Ptr{Cvoid}
 end
 
-type mpc_struct
-    r::mpf_struct
-    i::mpf_struct
-    mpc_struct() = new() # uninitialized
+mutable struct MpscStruct
+    r::MpfStruct
+    i::MpfStruct
+    mpsc_struct() = new()
 end
 
-type rdpe_struct
-    r::Cdouble
-    e::Clong
-end
+# struct RdpeStruct
+#     r::Cdouble
+#     e::Clong
+# end
 
-function setupMPSolve(n :: Integer)
-    ctx = ccall((:mps_context_new, "libmps"), Ptr{Void}, ())
+# mutable struct Cplx_struct
+#      r::Cdouble
+#      i::Cdouble
+# end
+
+function setupMPSolve(degree :: Integer)
+    ctx = ccall((:mps_context_new, "libmps"), Ptr{Cvoid}, ())
     mp  = ccall((:mps_monomial_poly_new, "libmps"), 
-                Ptr{Void}, (Ptr{Void}, Int), ctx, n)
+                            Ptr{Cvoid}, (Ptr{Cvoid}, Int), ctx, degree)
     (ctx, mp)
 end
 
-function solvePoly(ctx, mp)
-    ccall((:mps_context_set_input_poly, "libmps"), Void, 
-          (Ptr{Void}, Ptr{Void}), 
-          ctx, mp)
-    ccall((:mps_mpsolve, "libmps"), Void, (Ptr{Void},), ctx)
-end
-
-function getFloatingPointRoots(ctx, mp, n)
-    # Here we prepare some containers that will be used to pass a 
-    # double ** to MPSolve, using the function mps_context_get_roots_d(). 
-    # 
-    # That function will allocate memory to represent the results
-    # whose ownership will be transferred to Julia through the use 
-    # of pointer_to_array. 
-    app_container = Array(Ptr{Complex128}, 1)
-    radius_container = Array(Ptr{Float64}, 1)
-    app_container[1] = 0
-    radius_container[1] = 0
-
-    ccall((:mps_context_get_roots_d, "libmps"), Void, 
-          (Ptr{Void}, Ptr{Ptr{Complex128}}, Ptr{Ptr{Float64}}),
-          ctx, app_container, radius_container)
-    display(app_container[1])
-
-    approximations = pointer_to_array(app_container[1], n, true)
-    radius = pointer_to_array(radius_container[1], n, true)
-
-    (approximations, radius)
-end
-
-function getGMPRoots(ctx, mp, n)
-    # Obtain a copy of the approximations and radii represented
-    # as Complex{BigFloat} and BigFloat, respectively. 
-
-    app_container = Array(Ptr{mpc_struct}, 1)
-    app_container[1] = 0
-
-    radius_container = Array(Ptr{rdpe_struct}, 1)
-    radius_container[1] = 0
-
-    ccall((:mps_context_get_roots_m, "libmps"), Void, 
-          (Ptr{Void}, Ptr{Ptr{mpc_struct}}, Ptr{Ptr{rdpe_struct}}),
-          ctx, app_container, radius_container)
-
-    display(app_container[1])
-    # mpf_approximations = pointer_to_array(app_container[1], n, true)
+function solve_poly(cf::Vector{Float64})
+    degree = length(cf) - 1
     
-    # Convert mpf_t approximatino to the internal mpfr type of 
-    # Julia, so we can map them back to BigFloats
 end
-
-function releaseMPSolveContext(ctx, mp)
-    ccall((:mps_monomial_poly_free, "libmps"), Void, (Ptr{Void}, Ptr{Void}), 
-          ctx, mp)
-    ccall((:mps_context_free, "libmps"), Void, (Ptr{Void},), ctx)
-end
-
-"""
-(approximations, radii) = mps_roots(p) approximates
-the roots of the polynomial p(x). 
-"""
-function mps_roots(p::Poly{Complex{Float64}})
-
-    coefficients = p.a
-    n = length(coefficients) - 1
-
-    (ctx, mp) = setupMPSolve(n)
     
-    for i = 1 : n + 1
-        ccall((:mps_monomial_poly_set_coefficient_d, "libmps"), Void, 
-              (Ptr{Void}, Ptr{Void}, Int, Float64, Float64), 
-              ctx, mp, i-1, real(coefficients[i]), imag(coefficients[i]))
-    end
 
-    solvePoly(ctx, mp)
-    (approximations, radius) = getFloatingPointRoots(ctx, mp, n)
-    releaseMPSolveContext(ctx, mp)
+# function solve_poly(ctx, mp)
+#     ccall((:mps_context_set_input_poly, "libmps"), Cvoid, 
+#           (Ptr{Cvoid}, Ptr{Cvoid}),
+#           ctx, mp)
+#     print("Enter mps_mpsolve()\n")
+#     ccall((:mps_mpsolve, "libmps"), Cvoid, (Ptr{Cvoid},), ctx)
+#     print("Leave mps_mpsolve()\n")
+# end
 
-    (approximations, radius)
+# function get_floating_point_roots(ctx, mp, n)
+#     # Here we prepare some containers that will be used to pass a 
+#     # double ** to MPSolve, using the function mps_context_get_roots_d(). 
+#     # 
+#     # That function will allocate memory to represent the results
+#     # whose ownership will be transferred to Julia through the use 
+#     # of pointer_to_array. 
+#     app_container = Array{Ptr{Nothing}}(undef, 1)
+#     radius_container = Array{Ptr{Nothing}}(undef, 1)
+#     app_container[1] = C_NULL
+#     radius_container[1] = C_NULL
+#     #app_container = Ref(C_NULL)
+#     #radius_container = Ref(C_NULL)
+    
+#     ccall((:mps_context_get_roots_d, "libmps"), Cvoid, 
+#           (Ptr{Cvoid}, Ref{Ptr{Nothing}}, Ref{Ptr{Nothing}}),
+#           ctx, app_container, radius_container)
+#     # display(app_container[1])
+
+#     # approximations = unsafe_wrap(app_container[1], n, true)
+#     # radius = unsafe_wrap(radius_container[1], n, true)
+
+#     # (approximations, radius)
+# end
+
+# # function getGMPRoots(ctx, mp, n)
+# #     # Obtain a copy of the approximations and radii represented
+# #     # as Complex{BigFloat} and BigFloat, respectively. 
+
+# #     app_container = Array(Ptr{MpscStruct}, 1)
+# #     app_container[1] = 0
+
+# #     radius_container = Array(Ptr{RdpeStruct}, 1)
+# #     radius_container[1] = 0
+
+# #     ccall((:mps_context_get_roots_m, "libmps"), Cvoid, 
+# #           (Ptr{Cvoid}, Ptr{Ptr{MpscStruct}}, Ptr{Ptr{RdpeStruct}}),
+# #           ctx, app_container, radius_container)
+
+# #     display(app_container[1])
+# #     # mpf_approximations = pointer_to_array(app_container[1], n, true)
+    
+# #     # Convert mpf_t approximatino to the internal mpfr type of 
+# #     # Julia, so we can map them back to BigFloats
+# # end
+
+# function release_mpsolve_context(ctx, mp)
+#     ccall((:mps_monomial_poly_free, "libmps"), Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), 
+#           ctx, mp)
+#     ccall((:mps_context_free, "libmps"), Cvoid, (Ptr{Cvoid},), ctx)
+# end
+
+# # """
+# # (approximations, radii) = mps_roots(p) approximates
+# # the roots of the polynomial p(x). 
+# # """
+# function mps_roots(p::Poly{Complex{Float64}})
+
+#     coefficients = p.a
+#     n = length(coefficients) - 1
+
+#     (ctx, mp) = setupMPSolve(n)
+    
+#     for i = 1 : n + 1
+#         ccall((:mps_monomial_poly_set_coefficient_d, "libmps"), Cvoid, 
+#               (Ptr{Cvoid}, Ptr{Cvoid}, Int, Float64, Float64), 
+#               ctx, mp, i-1, real(coefficients[i]), imag(coefficients[i]))
+#     end
+
+#     solve_poly(ctx, mp)
+#     (approximations, radius) = get_floating_point_roots(ctx, mp, n)
+#     release_mpsolve_context(ctx, mp)
+
+#     (approximations, radius)
+# end
+
+# mps_roots(p::Poly{Float64}) = mps_roots(convert(Poly{Complex{Float64}}, p))
+
+# function mps_roots(p::Poly{Complex{Rational{BigInt}}})
+
+#     real_coefficients = real(p.a)
+#     imag_coefficients = imag(p.a)
+
+#     n = length(real_coefficients) - 1
+#     (ctx, mp) = setupMPSolve(n)
+
+#     for i = 1 : n + 1
+#         x = MpqStruct(real_coefficients[i])
+#         y = MpqStruct(imag_coefficients[i])
+
+#         ccall ((:mps_monomial_poly_set_coefficient_q, "libmps"), Cvoid,
+#                (Ptr{Cvoid}, Ptr{Cvoid}, Int, 
+#                 Ptr{MpqStruct}, Ptr{MpqStruct}), 
+#                ctx, mp, i-1, &x, &y)
+#     end    
+
+#     solvePoly(ctx, mp)
+
+#     # TODO: We should get the output as BigFloat numbers, instead
+#     # of truncating it to floating point. 
+#     (approximations, radius) = getFloatingPointRoots(ctx, mp, n)
+#     # (approximations, radius) = getGMPRoots(ctx, mp, n)
+#     releaseMPSolveContext(ctx, mp)
+#     (approximations, radius)
+# end
+
+# # Generic methods defined using the conversion of Integer types to 
+# # BigInts and Rational{BigInt}s. 
+# mps_roots{T<:Integer}(p::Poly{Complex{T}}) = mps_roots(convert(Poly{Complex{Rational{BigInt}}}, p))
+# mps_roots{T<:Integer}(p::Poly{T}) = mps_roots(convert(Poly{Complex{Rational{BigInt}}}, p))
+# mps_roots{T<:Integer}(p::Poly{Rational{T}}) = mps_roots(convert(Poly{Complex{Rational{BigInt}}}, p))
+
+# function mps_roots(p::Poly{Complex{BigFloat}})
+#     real_coefficients = real(p.a)
+#     imag_coefficients = imag(p.a)
+
+#     n = length(real_coefficients) - 1
+#     (ctx, mp) = setupMPSolve(n)
+
+#     # TODO: Finish to implement this function
+# end
+
+# mps_roots(p::Poly{BigFloat}) = mps_roots(convert(Poly{Complex{BigFloat}}, p))
+
 end
-
-mps_roots(p::Poly{Float64}) = mps_roots(convert(Poly{Complex{Float64}}, p))
-
-function mps_roots(p::Poly{Complex{Rational{BigInt}}})
-
-    real_coefficients = real(p.a)
-    imag_coefficients = imag(p.a)
-
-    n = length(real_coefficients) - 1
-    (ctx, mp) = setupMPSolve(n)
-
-    for i = 1 : n + 1
-        x = mpq_struct(real_coefficients[i])
-        y = mpq_struct(imag_coefficients[i])
-
-        ccall ((:mps_monomial_poly_set_coefficient_q, "libmps"), Void,
-               (Ptr{Void}, Ptr{Void}, Int, 
-                Ptr{mpq_struct}, Ptr{mpq_struct}), 
-               ctx, mp, i-1, &x, &y)
-    end    
-
-    solvePoly(ctx, mp)
-
-    # TODO: We should get the output as BigFloat numbers, instead
-    # of truncating it to floating point. 
-    (approximations, radius) = getFloatingPointRoots(ctx, mp, n)
-    # (approximations, radius) = getGMPRoots(ctx, mp, n)
-    releaseMPSolveContext(ctx, mp)
-    (approximations, radius)
-end
-
-# Generic methods defined using the conversion of Integer types to 
-# BigInts and Rational{BigInt}s. 
-mps_roots{T<:Integer}(p::Poly{Complex{T}}) = mps_roots(convert(Poly{Complex{Rational{BigInt}}}, p))
-mps_roots{T<:Integer}(p::Poly{T}) = mps_roots(convert(Poly{Complex{Rational{BigInt}}}, p))
-mps_roots{T<:Integer}(p::Poly{Rational{T}}) = mps_roots(convert(Poly{Complex{Rational{BigInt}}}, p))
-
-function mps_roots(p::Poly{Complex{BigFloat}})
-    real_coefficients = real(p.a)
-    imag_coefficients = imag(p.a)
-
-    n = length(real_coefficients) - 1
-    (ctx, mp) = setupMPSolve(n)
-
-    # TODO: Finish to implement this function
-end
-
-mps_roots(p::Poly{BigFloat}) = mps_roots(convert(Poly{Complex{BigFloat}}, p))
-
-end ## End of Module MPSolve

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,111 +1,74 @@
 # Testing for the MPSolve.jl package. 
 
-using Polynomials
 using MPSolve
-using Base.Test
+using Test
+
+unity_roots(n) = [exp(j*2im*BigFloat(pi)/n) for j = 1:n]
+
+function solve_test(p, rts)
+    (app, rad) = mps_roots(p, 54)
+    I = sortperm(app, by=angle)
+    dist = map(abs, app[I] - sort(rts, by=angle))
+    @test all(dist <= rad[I])
+end
 
 function test_roots_of_unity(n)
-    nroots = [ exp(j * 1im * 2 * pi / n) for j = 1 : n ]
-    
-    p = Int64[ 0 for i = 1 : n + 1 ]
+    p = Int64[0 for i = 1:n + 1]
     p[1] = 1
     p[end] = -1
-
-    p = Poly(p)
-
-    (app, rad) = mps_roots(p)
-
-    for i = 1 : n
-        (err, ind) = findmin(abs(app - nroots[i]))
-        @test err <= rad[ind]
-    end
+    solve_test(p, unity_roots(n))
 end
 
 function test_roots_of_unity_fp(n)
-    nroots = [ exp(j * 1im * 2 * pi / n) for j = 1 : n ]
-    
     p = zeros(n+1)
     p[1] = 1.0
     p[end] = -1.0
-
-    p = Poly(p)
-
-    (app, rad) = mps_roots(p)
-
-    for i = 1 : n
-        (err, ind) = findmin(abs(app - nroots[i]))
-        @test err <= rad[ind]
-    end
+    solve_test(p, unity_roots(n))
 end
 
 function test_roots_of_unity_bigint(n)
-    nroots = [ exp(j * 1im * 2 * pi / n) for j = 1 : n ]
-    
-    p = [ BigInt(0) for i = 1 : n + 1 ]
+    p = [BigInt(0) for i = 1 : n + 1]
     p[1] = BigInt(1)
     p[end] = BigInt(-1)
-
-    p = Poly(p)
-
-    (app, rad) = mps_roots(p)
-
-    for i = 1 : n
-        (err, ind) = findmin(abs(app - nroots[i]))
-        @test err <= rad[ind]
-    end    
+    solve_test(p, unity_roots(n))
 end
 
 """
-Test if solving a polynomial with complex integer coefficienta
+Test if solving a polynomial with complex integer coefficients
 works. 
 """
+function roots2coeffs(roots)
+    coeffs = [0im for n = 1:length(roots) + 1]
+    coeffs[1] = 1
+    for i = 1:length(roots)
+        c = -roots[i]*coeffs[1:i + 1]
+        c[2:i + 1] += coeffs[1:i]
+        coeffs[1:i + 1] = c
+    end
+    coeffs
+end
+
 function test_complex_int()
     sols = [ 2 ; 3+1im ; 5-1im ; -2 ]
-
-    p = Poly([ 1 ])
-    for i = 1 : length(sols)
-        p = p * Poly([ - sols[i] ; 1 ])
-    end
-
-    (app,rad) = mps_roots(p)
-    
-    for i = 1 : length(sols)
-        (err, ind) = findmin(abs(app - sols))
-        @test err <= rad[ind]
-    end        
+    p = roots2coeffs(sols)
+    solve_test(p, sols)
 end
 
 function test_complex_bigint()
     sols = Complex{BigInt}[ 2 ; 3+1im ; 5-1im ; -2 ]
-
-    p = Poly([ BigInt(1) ])
-    for i = 1 : length(sols)
-        p = p * Poly([ - sols[i] ; BigInt(1) ])
-    end
-
-    (app,rad) = mps_roots(p)
-    
-    for i = 1 : length(sols)
-        (err, ind) = findmin(abs(app - sols))
-        @test err <= rad[ind]
-    end
+    p = roots2coeffs(sols)
+    solve_test(p, sols)
 end
 
 function test_roots_of_unity_bigfloat(n)
-    nroots = Complex{BigFloat}[ exp(1im * 2 * j * pi / n) for j = 1 : n ]
-    
     p = [ BigFloat(0) for i = 1 : n + 1 ]
-    p[1] = BigFloat(1)
-    p[end] = BigFloat(-1)
+    p[1] = 1
+    p[end] = -1
+    solve_test(p, unity_roots(n))
+end
 
-    p = Poly(p)
-
-    (app, rad) = mps_roots(p)
-
-    for i = 1 : n
-        (err, ind) = findmin(abs(app - nroots[i]))
-        @test err <= rad[ind]
-    end
+if VERSION < v"1.3-rc4"
+    error("This module only works with Julia version 1.3-rc4 or greater")
 end
 
 N = 100
@@ -113,6 +76,6 @@ N = 100
 test_roots_of_unity(N)
 test_roots_of_unity_fp(N)
 test_roots_of_unity_bigint(N)
-# test_roots_of_unity_bigfloat(N)
+test_roots_of_unity_bigfloat(N)
 test_complex_int()
 test_complex_bigint()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,9 +7,10 @@ unity_roots(n) = [exp(j*2im*BigFloat(pi)/n) for j = 1:n]
 
 function solve_test(p, rts)
     (app, rad) = mps_roots(p, 54)
-    I = sortperm(app, by=angle)
-    dist = map(abs, app[I] - sort(rts, by=angle))
-    @test all(dist <= rad[I])
+    for i = 1:length(rts)
+        (err, ind) = findmin(map(abs, app .- rts[i]))
+        @test err <= rad[ind]
+    end
 end
 
 function test_roots_of_unity(n)


### PR DESCRIPTION
This is more a complete rewrite than a fix, as the language have changed a great deal. It requires version 1.3 release candidate or nightly to work, as Julia 1.2 has memory allocation bug that crashed the solver.